### PR TITLE
Updated validation for `getLastVestingScheduleForHolder()` in Vesting contract

### DIFF
--- a/contracts/vesting/Vesting.sol
+++ b/contracts/vesting/Vesting.sol
@@ -299,7 +299,8 @@ contract Vesting is Ownable, ReentrancyGuard{
         public
         view
         returns(VestingSchedule memory){
-        return vestingSchedules[computeVestingScheduleIdForAddressAndIndex(holder, holdersVestingCount[holder] - 1)];
+            require(holdersVestingCount[holder] > 0, "Vesting::This address doesn't have any vested tokens");
+            return vestingSchedules[computeVestingScheduleIdForAddressAndIndex(holder, holdersVestingCount[holder] - 1)];
     }
 
     /**


### PR DESCRIPTION
Added the validation to check if the holdersVestingCount is greater than 0 for `getLastVestingScheduleForHolder()` function in the Vesting contract.

The `require` statement was not in place below due to which the function will revert without an error if the function is called by a user who does not have any tokens vested.